### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,10 @@ on:
     paths:
       - 'src/**'
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/Shikazi/NFormula/security/code-scanning/2](https://github.com/Shikazi/NFormula/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the operations performed in the workflow:
- `contents: read` is required to read repository files.
- `packages: write` is required to push packages to NuGet.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the `build` job to limit permissions to that specific job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
